### PR TITLE
ENH: Return transform from registration methods

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -16,17 +16,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "60c2920599013d20293432902cb9d775eb87d0b2"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "60c2920599013d20293432902cb9d775eb87d0b2"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "60c2920599013d20293432902cb9d775eb87d0b2"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -185,7 +185,7 @@ jobs:
       matrix:
         python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.2rc03"
 
     steps:
     - uses: actions/checkout@v2
@@ -230,7 +230,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.2rc03"
 
     steps:
     - uses: actions/checkout@v2
@@ -273,7 +273,7 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.2rc03"
 
     steps:
     - name: Get specific version of CMake, Ninja

--- a/src/hasi/hasi/diffeoregistrar.py
+++ b/src/hasi/hasi/diffeoregistrar.py
@@ -32,6 +32,8 @@ class DiffeoRegistrar(MeshToMeshRegistrar):
 
     # Definitions for diffeometric registration
     STANDARD_DEVIATIONS = 1.0
+    TransformType = \
+        itk.DisplacementFieldTransform[itk.F, Dimension]
 
 
     def __init__(self):
@@ -54,7 +56,7 @@ class DiffeoRegistrar(MeshToMeshRegistrar):
                  target_mesh:MeshType,
                  filepath:str=None,
                  verbose=False,
-                 max_iterations=MAX_ITERATIONS) -> MeshType:
+                 max_iterations=MAX_ITERATIONS) -> (TransformType, MeshType):
         template_image = self.mesh_to_image(template_mesh)
         target_image = self.mesh_to_image(target_mesh,template_image)
 
@@ -74,9 +76,7 @@ class DiffeoRegistrar(MeshToMeshRegistrar):
         self.filter.Update()
         
         # Update template mesh to match target
-        DisplacementFieldTransformType = \
-            itk.DisplacementFieldTransform[itk.F, self.Dimension]
-        transform = DisplacementFieldTransformType.New()
+        transform = self.TransformType.New()
         transform.SetDisplacementField(self.filter.GetOutput())
 
         # TODO pythonic style
@@ -93,4 +93,4 @@ class DiffeoRegistrar(MeshToMeshRegistrar):
             if(verbose):
                 print(f'Wrote resulting mesh to {filepath}')
 
-        return transform_filter.GetOutput()
+        return (transform, transform_filter.GetOutput())

--- a/src/hasi/hasi/meansquaresregistrar.py
+++ b/src/hasi/hasi/meansquaresregistrar.py
@@ -45,6 +45,7 @@ class MeanSquaresRegistrar(MeshToMeshRegistrar):
     # TODO investigate if this is useful
     LinearInterpolatorType = \
         itk.LinearInterpolateImageFunction[ImageType, itk.D]
+    TransformType = itk.BSplineTransform[itk.D, Dimension, V_SPLINE_ORDER]
     
 
     def __init__(self):
@@ -64,7 +65,7 @@ class MeanSquaresRegistrar(MeshToMeshRegistrar):
                  target_mesh:MeshType,
                  filepath:str=None,
                  verbose=False,
-                 num_iterations=MAX_ITERATIONS) -> MeshType:
+                 num_iterations=MAX_ITERATIONS) -> (TransformType, MeshType):
 
         template_image = self.mesh_to_image(template_mesh)
         target_image = self.mesh_to_image(target_mesh, template_image)
@@ -82,8 +83,7 @@ class MeanSquaresRegistrar(MeshToMeshRegistrar):
             fixed_physical_dimensions.append(template_image.GetSpacing()[i] * \
                 (template_image.GetLargestPossibleRegion().GetSize()[i] - 1))
             
-        TransformType = itk.BSplineTransform[itk.D, Dimension, self.V_SPLINE_ORDER]
-        transform = TransformType.New(TransformDomainOrigin=fixed_origin,
+        transform = self.TransformType.New(TransformDomainOrigin=fixed_origin,
                                             TransformDomainPhysicalDimensions=fixed_physical_dimensions,
                                             TransformDomainDirection=template_image.GetDirection())
         transform.SetTransformDomainMeshSize([self.GRID_NODES_IN_ONE_DIMENSION - self.V_SPLINE_ORDER] * Dimension)
@@ -145,4 +145,4 @@ class MeanSquaresRegistrar(MeshToMeshRegistrar):
             if(verbose):
                 print(f'Wrote resulting mesh to {filepath}')
 
-        return transformed_mesh
+        return (transform, transformed_mesh)

--- a/src/hasi/hasi/meshtomeshregistrar.py
+++ b/src/hasi/hasi/meshtomeshregistrar.py
@@ -35,7 +35,7 @@ class MeshToMeshRegistrar:
         pass
     
     def register(self, template_mesh:MeshType, target_mesh:MeshType,
-                       filepath:str=None, verbose=False) -> MeshType:
+                       filepath:str=None, verbose=False):
         raise NotImplementedError('Base class does not implement register functionality')
 
     # Convert itk.Mesh object to 3-dimensional itk.Image object

--- a/src/hasi/test_meshtomeshregistration.py
+++ b/src/hasi/test_meshtomeshregistration.py
@@ -20,7 +20,7 @@ if module_path not in sys.path:
 import itk
 
 MEANSQUARES_METRIC_MAXIMUM_THRESHOLD = 0.002
-DIFFEO_METRIC_MAXIMUM_THRESHOLD = 0.0001
+DIFFEO_METRIC_MAXIMUM_THRESHOLD = 0.0002
 MAX_ITERATIONS = 200
 
 FIXED_MESH_FILE = 'test/Input/901-L-mesh.vtk'
@@ -81,7 +81,7 @@ def test_meansquares_registration():
     registrar = MeanSquaresRegistrar()
 
     # Registration executes
-    mesh3 = registrar.register(mesh1,mesh2,filepath=MESH_OUTPUT)
+    (transform, mesh3) = registrar.register(mesh1,mesh2,filepath=MESH_OUTPUT)
 
     # Mesh was generated
     assert(type(mesh3) == type(mesh1))
@@ -92,7 +92,10 @@ def test_meansquares_registration():
   
     # Optimization did not exceed allowable iterations
     assert(registrar.optimizer.GetCurrentIteration() <= MAX_ITERATIONS)
-  
+
+    # Transform was output
+    assert(type(transform) == registrar.TransformType)
+
     # Mesh was output
     assert(os.path.isfile(MESH_OUTPUT))
 
@@ -116,7 +119,10 @@ def test_diffeo_registration():
     registrar = DiffeoRegistrar()
 
     # Registration executes without error
-    mesh4 = registrar.register(mesh1,mesh2,filepath=MESH_OUTPUT)
+    (transform, mesh4) = registrar.register(mesh1,mesh2,filepath=MESH_OUTPUT)
+    
+    # Transform was output
+    assert(type(transform) == registrar.TransformType)
 
     # Mesh was generated
     assert(type(mesh4) == type(mesh1))


### PR DESCRIPTION
Updates registration methods to return the tuple `(transform, transformed_mesh)` so that transforms may be used directly in shape analysis.