### PR TITLE
COMP: Fix CI. Closes #56.

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -170,10 +170,8 @@ jobs:
         ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }}
         popd
         cp ITKBoneEnhancement/include/* include/
-        rm ./ITKBoneEnhancement/doxygen-1.8.11.linux.bin.tar.gz
         rm ./ITKBoneEnhancement/ITKPythonBuilds-linux.tar.zst
         mv ./ITKBoneEnhancement/ITKPythonPackage .
-        mv ./ITKBoneEnhancement/tools .
         ./ITKPythonPackage/scripts/dockcross-manylinux-build-module-wheels.sh cp${{ matrix.python-version }}
 
     - name: Publish Python package as GitHub Artifact


### PR DESCRIPTION
rm dist/itk_boneenhancement-0.4.1-cp36-cp36m-linux_x86_64.whl
~/work/HASI/HASI
rm: cannot remove './ITKBoneEnhancement/doxygen-1.8.11.linux.bin.tar.gz': No such file or directory
Error: Process completed with exit code 1.