### PR TITLE
ENH: Update HASI python package dependencies

### DIFF
--- a/.github/workflows/test-python-hasi.yml
+++ b/.github/workflows/test-python-hasi.yml
@@ -2,9 +2,6 @@ name: Test Python HASI
 
 on: [push,pull_request]
 
-env:
-  ITKBoneEnhancement-git-tag: v0.4.1
-
 jobs:
   test-python-hasi-package:
     runs-on: ${{ matrix.os }}
@@ -28,8 +25,9 @@ jobs:
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install itk==5.2.0
-        python -m pip install itk-shape==0.2.0
+        python -m pip install itk==5.2.0.post2
+        python -m pip install itk-shape==0.2.1
+        python -m pip install dwd==1.0.1
         python -m pip install pytest
 
     - name: Test with pytest

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     install_requires=[
         r'itk>=5.2.0.post2',
         r'itk-boneenhancement>=0.4.2',
-        r'itk-ioscanco',
-        r'dwd>=1.0.1'
+        r'itk-ioscanco'
     ]
     )

--- a/src/hasi/hasi/__init__.py
+++ b/src/hasi/hasi/__init__.py
@@ -1,3 +1,3 @@
 """High-throughput Applications for Skeletal Imaging (HASI) Python content"""
 
-__version__ = '0.2'
+__version__ = '0.3.0'

--- a/src/hasi/pyproject.toml
+++ b/src/hasi/pyproject.toml
@@ -8,8 +8,9 @@ author = "Kitware Medical"
 author-email = "matt.mccormick@kitware.com"
 home-page = "https://github.com/KitwareMedical/HASI"
 requires = [
-    "itk-shape>=0.2.0",
-    "itk-hasi"
+    "itk-hasi>=0.2.2",
+    "itk-shape>=0.2.1",
+    "dwd>=1.0.1"
 ]
 requires-python=">=3.7"
 classifiers = [


### PR DESCRIPTION
Changes to separate dependencies for Python-only `hasi` package (shape analysis pipeline) from `itk-hasi` package (Python wrappings for cxx classes).
- Add `hasi` version to `pyproject.toml`
- Move `dwd` and `itk-shape` dependencies to `pyproject.toml` for `hasi` and out of `setup.py` for `itk-hasi`
- Updated `test-python-hasi` CI for `hasi` package dependencies only