### PR TITLE
ENH: Add test_integration.py data to IPFS

### DIFF
--- a/.github/workflows/test-python-hasi.yml
+++ b/.github/workflows/test-python-hasi.yml
@@ -32,6 +32,7 @@ jobs:
         python -m pip install matplotlib
         python -m pip install pytest
         python -m pip install pytest-dependency
+        python -m pip install ipfsspec xarray zarr
 
     - name: Test with pytest
       run: |

--- a/src/hasi/pyproject.toml
+++ b/src/hasi/pyproject.toml
@@ -36,5 +36,8 @@ classifiers = [
 [tool.flit.metadata.requires-extra]
 test = [
     "pytest >=6.2.1",
-    "pytest-dependency>=0.5.1"
+    "pytest-dependency>=0.5.1",
+    "ipfsspec",
+    "xarray",
+    "zarr"
 ]


### PR DESCRIPTION
Data created with script:

  #!/usr/bin/env python

  from pathlib import Path
  import os
  import subprocess
  import itk
  import zarr
  from numcodecs import Blosc
  import json

  femur_root = Path('/home/matt/data/hasi-femur-nrrd')
  ipfs_data_repo = Path('/home/matt/data/hasi-testing-data/femur')
  os.chdir(ipfs_data_repo)

  images = {}
  for image_nrrd in femur_root.iterdir():
      if image_nrrd.is_file():
          image = itk.imread(str(image_nrrd))
          image_da = itk.xarray_from_image(image)
          name = image_nrrd.stem
          print(name)
          image_ds = image_da.to_dataset(name=name)
          output_dir = ipfs_data_repo
          store = zarr.DirectoryStore(output_dir / (name + '.zarr'))
          chunk_size = 64
          compressor = Blosc(cname='zstd', clevel=5, shuffle=Blosc.SHUFFLE)
          image_ds.to_zarr(store, mode='w', compute=True,
                           encoding={name: {'chunks': [chunk_size]*image.GetImageDimension(), 'compressor': compressor}})
          cid = subprocess.check_output(['ipfs', 'add', '-r', '--hidden', '-s', 'size-1000000',
                                         '--raw-leaves', '--cid-version', '1', '-Q',
                                         str(name + '.zarr')]).decode().strip()
          images[str(name)] = cid

  index_json = ipfs_data_repo / 'index.json'
  with open(index_json, 'w') as fp:
      json.dump(images, fp)
  index_cid = subprocess.check_output(['ipfs', 'add', '-r', '--hidden', '-s', 'size-1000000',
      '--raw-leaves', '--cid-version', '1', '-Q', '-w',
                                 str(index_json)]).decode().strip()
  print('index_cid', index_cid)
