### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkLandmarkAtlasSegmentationFilter.hxx
+++ b/include/itkLandmarkAtlasSegmentationFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLandmarkAtlasSegmentationFilter_hxx
 #define itkLandmarkAtlasSegmentationFilter_hxx
 
-#include "itkLandmarkAtlasSegmentationFilter.h"
 
 #include "itkLandmarkBasedTransformInitializer.h"
 #include "itkResampleImageFilter.h"

--- a/include/itkSegmentBonesInMicroCTFilter.hxx
+++ b/include/itkSegmentBonesInMicroCTFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSegmentBonesInMicroCTFilter_hxx
 #define itkSegmentBonesInMicroCTFilter_hxx
 
-#include "itkSegmentBonesInMicroCTFilter.h"
 
 #include "itkArray.h"
 #include "itkMedianImageFilter.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

