### PR TITLE
COMP: Modules need updated version of ITK

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -16,17 +16,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.2.0"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.2.0"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.2.0"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
 
     steps:


### PR DESCRIPTION
COMP: Modules need updated version of ITK

Removal of .h includes from same named .hxx files
requires removal of outdated rule that is no longer
relevant.

This PR will update the version of ITK that is
used for the remove modules."



BRANCH_NAME=update-reference-itk-version
for remdir_script in *.remote.cmake; do
   
  remdir="${remdir_script//*.remote.cmake/}"
  if [ ! -d "${remdir}" ] ;then
    echo "Missing directory ${remdir}"
    continue
  fi
  pushd "${remdir}" || exit
  echo "=============== $(pwd) ========="
  git checkout master
  git fetch origin
  git rebase origin/master
  git checkout -b ${BRANCH_NAME}
  sed 's/itk-git-tag : .*/itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"/g' $( fgrep -Rl "itk-git-tag:" |fgrep yml )

  git status
  diff_line_no=$(git diff |wc -l )
  if [ "${diff_line_no}" -ne 0 ]; then
    git add -p
    git commit -F /tmp/update_itk_msg

    gh pr create -a "@me" -F /tmp/update_itk_msg
  else
    echo "Skipping changes $(pwd)"
  fi
  git fetch
  git rebase origin/master 
  git push origin -f ${BRANCH_NAME}:${BRANCH_NAME}

  popd || exit
done
