### PR TITLE
COMP: Removed redundant type alias.

### DIFF
--- a/include/itkSegmentBonesInMicroCTFilter.hxx
+++ b/include/itkSegmentBonesInMicroCTFilter.hxx
@@ -195,7 +195,6 @@ SegmentBonesInMicroCTFilter<TInputImage, TOutputImage>::GenerateData()
     progress->RegisterInternalFilter(multiScaleFilter, 0.5f);
     multiScaleFilter->Update();
 
-    using FloatThresholdType = BinaryThresholdImageFilter<RealImageType, TOutputImage>;
     typename FloatThresholdType::Pointer descoTh = FloatThresholdType::New();
     descoTh->SetInput(multiScaleFilter->GetOutput());
     descoTh->SetLowerThreshold(0.1);


### PR DESCRIPTION
This resolves the following compiler warning:
/localscratch/Users/kjweimer/ITK/Modules/Remote/HASI/include/itkSegmentBonesInMicroCTFilter.hxx:198:87: warning: declaration of ‘using FloatThresholdType = class itk::BinaryThresholdImageFilter<itk::Image<float, itk::SegmentBonesInMicroCTFilter<TInputImage, TOutputImage>::Dimension>, TOutputImage>’ shadows a member of ‘itk::SegmentBonesInMicroCTFilter<TInputImage, TOutputImage>’ [-Wshadow]

  198 |     using FloatThresholdType = BinaryThresholdImageFilter<RealImageType, TOutputImage>;
         |                                                                                       ^

In file included from /localscratch/Users/kjweimer/ITK/Modules/Remote/HASI/test/itkSegmentBonesInMicroCTFilterTest.cxx:19:
/localscratch/Users/kjweimer/ITK/Modules/Remote/HASI/include/itkSegmentBonesInMicroCTFilter.h:89:9: note: shadowed declaration is here

   89 |   using FloatThresholdType = BinaryThresholdImageFilter<RealImageType, TOutputImage>;
        |         ^~~~~~~~~~~~~~~~~~