### PR TITLE
COMP: Fix value comparision differences warning

### DIFF
--- a/include/itkSegmentBonesInMicroCTFilter.hxx
+++ b/include/itkSegmentBonesInMicroCTFilter.hxx
@@ -285,7 +285,7 @@ SegmentBonesInMicroCTFilter<TInputImage, TOutputImage>::GenerateData()
 
 
   // per-bone processing
-  for (unsigned bone = 1; bone <= numBones; bone++)
+  for (PixelType bone = 1; bone <= numBones; bone++)
   {
     float boneProgress = 0.3f / numBones;
     float beginProgress = 0.7 + boneProgress * (bone - 1);


### PR DESCRIPTION
comparison of integers of different signs:
  'PixelType' (aka 'short') and 'const unsigned int'

Patch provided in #86. Closes #86.