### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkLandmarkAtlasSegmentationFilter.h
+++ b/include/itkLandmarkAtlasSegmentationFilter.h
@@ -57,7 +57,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information. */
-  itkTypeMacro(LandmarkAtlasSegmentationFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(LandmarkAtlasSegmentationFilter);
 
   /** Standard New macro. */
   itkNewMacro(Self);

--- a/include/itkSegmentBonesInMicroCTFilter.h
+++ b/include/itkSegmentBonesInMicroCTFilter.h
@@ -56,7 +56,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information. */
-  itkTypeMacro(SegmentBonesInMicroCTFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(SegmentBonesInMicroCTFilter);
 
   /** Standard New macro. */
   itkNewMacro(Self);


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
